### PR TITLE
feat: Ignore config.xml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ const options: Options = {
     android: { icon: { sources: ['resources/icon.png'] } },
     ios: { splash: { sources: ['resources/splash.png'] } },
   },
+  ignoreConfigXML: false
 };
 
 await run(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ async function CordovaRes({
     [Platform.ANDROID]: generateRunOptions(Platform.ANDROID, resourcesDirectory, []),
     [Platform.IOS]: generateRunOptions(Platform.IOS, resourcesDirectory, []),
   },
+  ignoreConfigXML = false,
 }: CordovaRes.Options = {}): Promise<Result> {
   const configPath = path.resolve(directory, 'config.xml');
 
@@ -57,8 +58,10 @@ async function CordovaRes({
     }
   }
 
-  await runConfig(configPath, resourcesDirectory, sources, resources);
-  logstream.write(`Wrote to config.xml\n`);
+  if (ignoreConfigXML === false) {
+    await runConfig(configPath, resourcesDirectory, sources, resources);
+    logstream.write(`Wrote to config.xml\n`);
+  }
 
   return {
     resources: resources.map(resource => {
@@ -135,6 +138,13 @@ namespace CordovaRes {
      * provided, resources are generated in an explicit, opt-in manner.
      */
     readonly platforms?: Readonly<PlatformOptions>;
+
+    /**
+     * Ignore `config.xml` file
+     *
+     * Generate images without interacting with `config.xml` file
+     */
+    readonly ignoreConfigXML?: boolean;
   }
 
   export async function runCommandLine(args: ReadonlyArray<string>): Promise<void> {


### PR DESCRIPTION
This is for a use case where a designer needs to check the splash-screen design on different screen sizes without the need for an app or make use of the config.xml file.