### PR TITLE
feat: Warn if no config.xml file was found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { existsSync } from '@ionic/utils-fs';
 import Debug from 'debug';
 import path from 'path';
 
@@ -57,8 +58,16 @@ async function CordovaRes({
     }
   }
 
-  await runConfig(configPath, resourcesDirectory, sources, resources);
-  logstream.write(`Wrote to config.xml\n`);
+  if (existsSync(configPath)) {
+    await runConfig(configPath, resourcesDirectory, sources, resources);
+    logstream.write(`Wrote to config.xml\n`);
+  } else {
+    if (errstream) {
+      errstream.write(`WARN: Did not find config.xml file at ${directory}\n`);
+    } else {
+      debug('WARN: Did not find config.xml file at %s', directory);
+    }
+  }
 
   return {
     resources: resources.map(resource => {


### PR DESCRIPTION
This is for a use case where a designer needs to check the splash-screen design on different screen sizes without the need for an app or make use of the config.xml file.