### PR TITLE
Added support for the Windows 10 platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ resources/android/icon
 resources/android/splash
 resources/ios/icon
 resources/ios/splash
+resources/windows/icon
+resources/windows/splash
 ```
 
 ### Programmatic API

--- a/src/__tests__/platform.ts
+++ b/src/__tests__/platform.ts
@@ -62,6 +62,37 @@ describe('cordova-res', () => {
         expect(result.resources.length).toEqual(generatedImages.length);
       });
 
+      it('should run through windows icons with successful result', async () => {
+        const pipeline: any = { clone: jest.fn(() => pipeline) };
+        imageMock.resolveSourceImage.mockImplementation(async () => ({ src: 'test.png', image: { src: 'test.png', pipeline, metadata: {} } }));
+
+        const result = await platform.run(Platform.WINDOWS, 'resources', {
+          [ResourceType.ICON]: { sources: ['icon.png'] },
+        });
+
+        const generatedImages = getResourcesConfig(Platform.WINDOWS, ResourceType.ICON).resources;
+
+        expect(imageMock.resolveSourceImage).toHaveBeenCalledTimes(1);
+        expect(imageMock.resolveSourceImage).toHaveBeenCalledWith('windows', 'icon', ['icon.png'], undefined);
+        expect(imageMock.generateImage).toHaveBeenCalledTimes(generatedImages.length);
+
+        for (const generatedImage of generatedImages) {
+          expect(imageMock.generateImage).toHaveBeenCalledWith(
+              {
+                src: path.join('resources', generatedImage.src),
+                format: generatedImage.format,
+                width: generatedImage.width,
+                height: generatedImage.height,
+              },
+              expect.anything(),
+              expect.anything(),
+              undefined
+          );
+        }
+
+        expect(result.resources.length).toEqual(generatedImages.length);
+      });
+
     });
 
     describe('isSupportedPlatform', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,8 +84,10 @@ export function runConfig(configPath: string, resources: ReadonlyArray<Generated
 
   for (const [ platform, platformResources ] of platforms) {
     const platformElement = resolvePlatformElement(root, platform);
-    const filteredResources = platformResources.filter(img => orientation === 'default' || typeof img.orientation === 'undefined' || img.orientation === orientation);
-
+    let filteredResources = platformResources.filter(img => orientation === 'default' || typeof img.orientation === 'undefined' || img.orientation === orientation);
+    if (platform === Platform.WINDOWS) {
+      filteredResources = filteredResources.filter(img => typeof img.target === 'string');
+    }
     for (const resource of filteredResources) {
       runResource(configPath, resource, platformElement);
     }

--- a/src/image.ts
+++ b/src/image.ts
@@ -71,6 +71,10 @@ export interface ImageSchema {
 export async function generateImage(image: ImageSchema, src: Sharp, metadata: Metadata, errstream?: NodeJS.WritableStream): Promise<void> {
   debug('Generating %o (%ox%o)', image.src, image.width, image.height);
 
+  if (image.format === Format.NONE) {
+    return;
+  }
+
   if (errstream) {
     if (metadata.format !== image.format) {
       errstream.write(`WARN: Must perform conversion from ${metadata.format} to png.\n`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ interface ResultResource {
   height?: number;
   density?: Density;
   orientation?: Orientation;
+  target?: string;
 }
 
 interface ResultSource {
@@ -38,6 +39,7 @@ async function CordovaRes({
   platforms = {
     [Platform.ANDROID]: generateRunOptions(Platform.ANDROID, resourcesDirectory, []),
     [Platform.IOS]: generateRunOptions(Platform.IOS, resourcesDirectory, []),
+    [Platform.WINDOWS]: generateRunOptions(Platform.WINDOWS, resourcesDirectory, []),
   },
 }: CordovaRes.Options = {}): Promise<Result> {
   const configPath = path.resolve(directory, 'config.xml');

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -11,9 +11,10 @@ const debug = Debug('cordova-res:platform');
 export const enum Platform {
   ANDROID = 'android',
   IOS = 'ios',
+  WINDOWS = 'windows',
 }
 
-export const PLATFORMS: ReadonlyArray<Platform> = [Platform.ANDROID, Platform.IOS];
+export const PLATFORMS: ReadonlyArray<Platform> = [Platform.ANDROID, Platform.IOS, Platform.WINDOWS];
 
 export interface GeneratedResource extends ResourceKeyValues {
   type: ResourceType;

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -24,6 +24,23 @@ export const enum SourceType {
   // TODO: support vectors via Android XML
 }
 
+/**
+ * Windows targets
+ * @see https://cordova.apache.org/docs/en/latest/config_ref/images.html#windows
+ *
+ */
+export const enum WindowsTarget {
+  STORE_LOGO = 'StoreLogo',
+  SQUARE_30_X_30_LOGO = 'Square30x30Logo',
+  SQUARE_44_X_44_LOGO = 'Square44x44Logo',
+  SQUARE_70_X_70_LOGO = 'Square70x70Logo',
+  SQUARE_71_X_71_LOGO = 'Square71x71Logo',
+  SQUARE_150_X_150_LOGO = 'Square150x150Logo',
+  SQUARE_310_X_310_LOGO = 'Square310x310Logo',
+  WIDE_310_X_150_LOGO = 'Wide310x150Logo',
+  SPLASH_SCREEN = 'SplashScreen',
+}
+
 export interface ImageSource {
   type: SourceType.RASTER;
 
@@ -119,6 +136,7 @@ export const RASTER_RESOURCE_VALIDATORS: { readonly [T in ResourceType]: Resourc
 export const enum Format {
   PNG = 'png',
   JPEG = 'jpeg',
+  NONE = 'none',
 }
 
 export const enum Orientation {
@@ -156,6 +174,7 @@ export const enum ResourceKey {
   HEIGHT = 'height',
   DENSITY = 'density',
   ORIENTATION = 'orientation',
+  TARGET = 'target',
 }
 
 export interface ResourceKeyValues {
@@ -167,6 +186,7 @@ export interface ResourceKeyValues {
   readonly [ResourceKey.HEIGHT]?: number;
   readonly [ResourceKey.DENSITY]?: Density;
   readonly [ResourceKey.ORIENTATION]?: Orientation;
+  readonly [ResourceKey.TARGET]?: string;
 }
 
 export interface ResourcesImageConfig {
@@ -176,6 +196,7 @@ export interface ResourcesImageConfig {
   readonly [ResourceKey.HEIGHT]: number;
   readonly [ResourceKey.DENSITY]?: Density;
   readonly [ResourceKey.ORIENTATION]?: Orientation;
+  readonly [ResourceKey.TARGET]?: string;
 }
 
 export interface AndroidAdaptiveIconConfig {
@@ -237,6 +258,7 @@ const NodeAttributes = {
   DENSITY: { key: ResourceKey.DENSITY },
   WIDTH: { key: ResourceKey.WIDTH },
   HEIGHT: { key: ResourceKey.HEIGHT },
+  TARGET: { key: ResourceKey.TARGET },
 };
 
 export function getResourcesConfig(platform: Platform.ANDROID, type: ResourceType.ADAPTIVE_ICON): ResourcesTypeConfig<AndroidAdaptiveIconConfig>;
@@ -262,6 +284,97 @@ export function getResourcesConfig(platform: Platform, type: ResourceType): Reso
 }
 
 const RESOURCES: ResourcesConfig = {
+  [Platform.WINDOWS]: {
+    [ResourceType.ICON]: {
+      resources: [
+        /* @see https://cordova.apache.org/docs/en/latest/config_ref/images.html#windows */
+        /* @see https://docs.microsoft.com/en-us/windows/uwp/design/style/app-icons-and-logos */
+        /* @see https://docs.microsoft.com/en-us/windows/uwp/design/style/app-icons-and-logos#icon-types-locations-and-scale-factors */
+
+        /* App Icon: App list in start menu, task bar, task manager */
+        { src : 'windows/icon/Square44x44Logo.png', format: Format.NONE, width: 44, height: 44, target: WindowsTarget.SQUARE_44_X_44_LOGO },
+        { src : 'windows/icon/Square44x44Logo.scale-100.png', format: Format.PNG, width: 44, height: 44 },
+        { src : 'windows/icon/Square44x44Logo.scale-125.png', format: Format.PNG, width: 55, height: 55 },
+        { src : 'windows/icon/Square44x44Logo.scale-140.png', format: Format.PNG, width: 62, height: 62 },
+        { src : 'windows/icon/Square44x44Logo.scale-150.png', format: Format.PNG, width: 66, height: 66 },
+        { src : 'windows/icon/Square44x44Logo.scale-200.png', format: Format.PNG, width: 88, height: 88 },
+        { src : 'windows/icon/Square44x44Logo.scale-240.png', format: Format.PNG, width: 106, height: 106 },
+        { src : 'windows/icon/Square44x44Logo.scale-400.png', format: Format.PNG, width: 176, height: 176 },
+
+        /* Small tile: Start menu */
+        { src : 'windows/icon/SmallTile.png', format: Format.NONE, width: 71, height: 71, target: WindowsTarget.SQUARE_71_X_71_LOGO },
+        { src : 'windows/icon/SmallTile.scale-100.png', format: Format.PNG, width: 71, height: 71 },
+        { src : 'windows/icon/SmallTile.scale-125.png', format: Format.PNG, width: 89, height: 89 },
+        { src : 'windows/icon/SmallTile.scale-140.png', format: Format.PNG, width: 99, height: 99 },
+        { src : 'windows/icon/SmallTile.scale-150.png', format: Format.PNG, width: 107, height: 107 },
+        { src : 'windows/icon/SmallTile.scale-200.png', format: Format.PNG, width: 142, height: 142 },
+        { src : 'windows/icon/SmallTile.scale-240.png', format: Format.PNG, width: 170, height: 170 },
+        { src : 'windows/icon/SmallTile.scale-400.png', format: Format.PNG, width: 284, height: 284 },
+
+        /* Medium Tile: For Start menu, Microsoft Store listing */
+        { src : 'windows/icon/Square150x150Logo.png', format: Format.NONE, width: 150, height: 150, target: WindowsTarget.SQUARE_150_X_150_LOGO },
+        { src : 'windows/icon/Square150x150Logo.scale-100.png', format: Format.PNG, width: 150, height: 150 },
+        { src : 'windows/icon/Square150x150Logo.scale-125.png', format: Format.PNG, width: 188, height: 188 },
+        { src : 'windows/icon/Square150x150Logo.scale-140.png', format: Format.PNG, width: 210, height: 210 },
+        { src : 'windows/icon/Square150x150Logo.scale-150.png', format: Format.PNG, width: 225, height: 225 },
+        { src : 'windows/icon/Square150x150Logo.scale-200.png', format: Format.PNG, width: 300, height: 300 },
+        { src : 'windows/icon/Square150x150Logo.scale-240.png', format: Format.PNG, width: 360, height: 360 },
+        { src : 'windows/icon/Square150x150Logo.scale-400.png', format: Format.PNG, width: 600, height: 600 },
+
+        /* Large Tile: Start Menu */
+        { src : 'windows/icon/Square310x310Logo.png', format: Format.NONE, width: 310, height: 310, target: WindowsTarget.SQUARE_310_X_310_LOGO },
+        { src : 'windows/icon/Square310x310Logo.scale-100.png', format: Format.PNG, width: 310, height: 310 },
+        { src : 'windows/icon/Square310x310Logo.scale-125.png', format: Format.PNG, width: 388, height: 388 },
+        { src : 'windows/icon/Square310x310Logo.scale-140.png', format: Format.PNG, width: 434, height: 434 },
+        { src : 'windows/icon/Square310x310Logo.scale-150.png', format: Format.PNG, width: 465, height: 465 },
+        { src : 'windows/icon/Square310x310Logo.scale-180.png', format: Format.PNG, width: 558, height: 558 },
+        { src : 'windows/icon/Square310x310Logo.scale-200.png', format: Format.PNG, width: 620, height: 620 },
+        { src : 'windows/icon/Square310x310Logo.scale-400.png', format: Format.PNG, width: 1240, height: 1240 },
+
+        /* Wide Tile: Start Menu */
+        { src : 'windows/icon/Wide310x150Logo.png', format: Format.NONE, width: 248, height : 120, target: WindowsTarget.WIDE_310_X_150_LOGO },
+        { src : 'windows/icon/Wide310x150Logo.scale-80.png', format: Format.PNG, width: 248, height : 120 },
+        { src : 'windows/icon/Wide310x150Logo.scale-100.png', format: Format.PNG, width: 310, height : 150 },
+        { src : 'windows/icon/Wide310x150Logo.scale-125.png', format: Format.PNG, width: 388, height : 188 },
+        { src : 'windows/icon/Wide310x150Logo.scale-140.png', format: Format.PNG, width: 434, height : 210 },
+        { src : 'windows/icon/Wide310x150Logo.scale-150.png', format: Format.PNG, width: 465, height : 225 },
+        { src : 'windows/icon/Wide310x150Logo.scale-180.png', format: Format.PNG, width: 558, height : 270 },
+        { src : 'windows/icon/Wide310x150Logo.scale-200.png', format: Format.PNG, width: 620, height : 300 },
+        { src : 'windows/icon/Wide310x150Logo.scale-240.png', format: Format.PNG, width: 744, height : 360 },
+        { src : 'windows/icon/Wide310x150Logo.scale-400.png', format: Format.PNG, width: 1240, height : 600 },
+
+        /* Store Logo: App installer, Partner Center, the "Report an app" option in the Store, the "Write a review" option in the Store */
+        { src : 'windows/icon/StoreLogo.png', format: Format.NONE, width: 50, height: 50, target: WindowsTarget.STORE_LOGO },
+        { src : 'windows/icon/StoreLogo.scale-100.png', format: Format.PNG, width: 50, height: 50 },
+        { src : 'windows/icon/StoreLogo.scale-125.png', format: Format.PNG, width: 63, height: 63 },
+        { src : 'windows/icon/StoreLogo.scale-140.png', format: Format.PNG, width: 70, height: 70 },
+        { src : 'windows/icon/StoreLogo.scale-150.png', format: Format.PNG, width: 75, height: 75 },
+        { src : 'windows/icon/StoreLogo.scale-180.png', format: Format.PNG, width: 90, height: 90 },
+        { src : 'windows/icon/StoreLogo.scale-200.png', format: Format.PNG, width: 100, height: 100 },
+        { src : 'windows/icon/StoreLogo.scale-240.png', format: Format.PNG, width: 120, height: 120 },
+        { src : 'windows/icon/StoreLogo.scale-400.png', format: Format.PNG, width: 200, height: 200 },
+
+      ],
+      nodeName: 'icon',
+      nodeAttributes: [NodeAttributes.SRC, NodeAttributes.TARGET], /* NodeAttributes.WIDTH, NodeAttributes.HEIGHT, */
+      indexAttribute: NodeAttributes.SRC,
+    },
+    [ResourceType.SPLASH]: {
+      resources: [
+        /* @see https://msdn.microsoft.com/en-us/windows/desktop/hh465338 */
+        /* @see https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-splashscreen/index.html#windows-specific-information */
+        { src: 'windows/splash/Splash.png', format: Format.PNG, width: 620, height: 300, orientation: Orientation.LANDSCAPE, target: WindowsTarget.SPLASH_SCREEN },
+        { src: 'windows/splash/Splash.scale-100.png', format: Format.PNG, width: 620, height: 300, orientation: Orientation.LANDSCAPE },
+        { src: 'windows/splash/Splash.scale-125.png', format: Format.PNG, width: 775, height: 375, orientation: Orientation.LANDSCAPE },
+        { src: 'windows/splash/Splash.scale-150.png', format: Format.PNG, width: 930, height: 450, orientation: Orientation.LANDSCAPE },
+        { src: 'windows/splash/Splash.scale-200.png', format: Format.PNG, width: 1240, height: 600, orientation: Orientation.LANDSCAPE },
+        { src: 'windows/splash/Splash.scale-400.png', format: Format.PNG, width: 2480, height: 1200, orientation: Orientation.LANDSCAPE },
+      ],
+      nodeName: 'splash',
+      nodeAttributes: [NodeAttributes.SRC, NodeAttributes.TARGET], /* NodeAttributes.WIDTH, NodeAttributes.HEIGHT, */
+      indexAttribute: NodeAttributes.SRC,
+    },
+  },
   [Platform.ANDROID]: {
     [ResourceType.ICON]: {
       resources: [


### PR DESCRIPTION
Hi guys,

Here I've done the work to create icons for the Windows 10 platform.

This PR supports "MRT" icons for Windows, which is Windows' version of resolution scaling, and Cordova's recommended approach as outlined on their Windows platform guide.

## Implementation details

Like Android and iOS, Windows needs to generate lots of images at different scales, but unlike the other platforms it then summarises those images together using "targets" in the configuration, meaning the code needs to generate more images than it writes to the config file.

This is achieved in code by adding a `target` attribute into the resources definition, and ensuring that that only images with that attribute are written to the config file. Likewise, the MRT approach also needs the summary image filename to NOT have an actual file for MRT to work. To do this, I implemented a Format of `NONE` for those records.

## Example

e.g. Here's a snippet from the resources definition:

```
{ src : 'windows/icon/Square44x44Logo.png', format: Format.NONE, width: 44, height: 44, target: WindowsTarget.SQUARE_44_X_44_LOGO },
{ src : 'windows/icon/Square44x44Logo.scale-100.png', format: Format.PNG, width: 44, height: 44 },
{ src : 'windows/icon/Square44x44Logo.scale-125.png', format: Format.PNG, width: 55, height: 55 },
```

For the above example, the first line results in the config entry below, but no file is generated:

```
<icon src="res/windows/icon/SmallTile.png" target="Square71x71Logo" />
```

The other resource lines that follow generate the actual files normally:

```
Square44x44Logo.scale-100.png
Square44x44Logo.scale-125.png
Square44x44Logo.scale-140.png
Square44x44Logo.scale-150.png
Square44x44Logo.scale-200.png
Square44x44Logo.scale-240.png
Square44x44Logo.scale-400.png
```

MRT means that when `res/windows/icon/Square44x44Logo.png` is not found, that Windows looks instead for the scaled version of the image — e.g. `res/windows/icon/Square44x44Logo.scale-100.png`. 

The end result is 57 files generated and 7 config lines added.

## Code changes

- A new `Format.NONE` type indicates that the file should not be written
- A new `Platform.WINDOWS` type defines the Windows platform
- A new `WindowsTargets` enum holding all the Windows targets
- Added `target` to the types that define and pass around the source images.
- Added support through various parts of the code for the windows platform
- Added a test.

Results in the config look like this:

```
    <platform name="windows">
        <icon src="res/windows/icon/SmallTile.png" target="Square71x71Logo" />
        <icon src="res/windows/icon/Square150x150Logo.png" target="Square150x150Logo" />
        <icon src="res/windows/icon/Wide310x150Logo.png" target="Wide310x150Logo" />
        <icon src="res/windows/icon/Square310x310Logo.png" target="Square310x310Logo" />
        <icon src="res/windows/icon/Square44x44Logo.png" target="Square44x44Logo" />
        <icon src="res/windows/icon/StoreLogo.png" target="StoreLogo" />
        <splash src="res/windows/splash/Splash.png" target="SplashScreen" />
    </platform>
```

## Testing

I added a test to cover it, at the same standard as the existing tests. I also am running it for a production app I'm generating at present so I have real-world experience.

## Usage

A sample run of this patch looks like this:

```
$ cordova-res --resources res --icon-source res/icon.png --splash-source res/splash.png

Generated 18 resources for android
Generated 45 resources for ios
Generated 57 resources for windows
Wrote to config.xml
```


