### PR TITLE
Adding specs for missing Apple watch icon and iPhoneX splash screens.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-res",
-  "version": "0.7.0",
+  "version": "0.6.0",
   "description": "This tool will crop and resize PNG source images into appropriate sizes for modern iOS and Android devices.",
   "homepage": "https://ionicframework.com",
   "author": "Ionic Team <hi@ionicframework.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-res",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "This tool will crop and resize PNG source images into appropriate sizes for modern iOS and Android devices.",
   "homepage": "https://ionicframework.com",
   "author": "Ionic Team <hi@ionicframework.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-res",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "This tool will crop and resize PNG source images into appropriate sizes for modern iOS and Android devices.",
   "homepage": "https://ionicframework.com",
   "author": "Ionic Team <hi@ionicframework.com>",

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -425,6 +425,7 @@ const RESOURCES: ResourcesConfig = {
         { src: 'ios/icon/icon-44@2x.png', format: Format.PNG, width: 88, height: 88 },
         { src: 'ios/icon/icon-86@2x.png', format: Format.PNG, width: 172, height: 172 },
         { src: 'ios/icon/icon-98@2x.png', format: Format.PNG, width: 196, height: 196 },
+        { src: 'ios/icon/icon-108@2x.png', format: Format.PNG, width: 216, height: 216 },
         { src: 'ios/icon/icon-40.png', format: Format.PNG, width: 40, height: 40 },
         { src: 'ios/icon/icon-40@2x.png', format: Format.PNG, width: 80, height: 80 },
         { src: 'ios/icon/icon-40@3x.png', format: Format.PNG, width: 120, height: 120 },
@@ -451,6 +452,10 @@ const RESOURCES: ResourcesConfig = {
       resources: [
         { src: 'ios/splash/Default-568h@2x~iphone.png', format: Format.PNG, width: 640, height: 1136, orientation: Orientation.PORTRAIT },
         { src: 'ios/splash/Default-667h.png', format: Format.PNG, width: 750, height: 1334, orientation: Orientation.PORTRAIT },
+        { src: 'ios/splash/Default-2688h~iphone.png', format: Format.PNG, width: 1242, height: 2688, orientation: Orientation.PORTRAIT },
+        { src: 'ios/splash/Default-Landscape-2688h~iphone.png', format: Format.PNG, width: 2688, height: 1242, orientation: Orientation.LANDSCAPE },
+        { src: 'ios/splash/Default-1792h~iphone.png', format: Format.PNG, width: 828, height: 1792, orientation: Orientation.PORTRAIT },
+        { src: 'ios/splash/Default-Landscape-1792h~iphone.png', format: Format.PNG, width: 1792, height: 828, orientation: Orientation.LANDSCAPE },
         { src: 'ios/splash/Default-2436h.png', format: Format.PNG, width: 1125, height: 2436, orientation: Orientation.PORTRAIT },
         { src: 'ios/splash/Default-Landscape-2436h.png', format: Format.PNG, width: 2436, height: 1125, orientation: Orientation.LANDSCAPE },
         { src: 'ios/splash/Default-736h.png', format: Format.PNG, width: 1242, height: 2208, orientation: Orientation.PORTRAIT },


### PR DESCRIPTION
Partially addresses this issue, https://github.com/ionic-team/cordova-res/issues/48, in that it generates the 108@x2 icon for Apple Watch.

The issue regarding that icon not being copied over to **Images.xcassets/AppIcon.appiconset** is on Cordova to resolve.  The `cordova prepare` command copies over the icons based on what's defined in **config.xml**, however, I've noticed that it doesn't copy over all of the specified icons. I'm guessing that Cordova maintains an internal list of which icons to copy over. This is true of Splash screens too.