### PR TITLE
Added copying generated resources to native project directly

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -12,7 +12,11 @@ describe('cordova-res', () => {
         logstream: process.stdout,
         errstream: process.stderr,
         resourcesDirectory: 'resources',
-        nativeProjectDirectory: '',
+        nativeProject: {
+          enabled: false,
+          androidProjectDirectory: '',
+          iosProjectDirectory: '',
+        },
       };
 
       it('should parse default options with no arguments', () => {

--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -12,6 +12,7 @@ describe('cordova-res', () => {
         logstream: process.stdout,
         errstream: process.stderr,
         resourcesDirectory: 'resources',
+        nativeProjectDirectory: '',
       };
 
       it('should parse default options with no arguments', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,9 +30,9 @@ export function parseOptions(args: readonly string[]): Options {
   const platformArg = args[0] ? args[0] : undefined;
   const platformList = validatePlatforms(platformArg && !platformArg.startsWith('-') ? [platformArg] : []);
   const nativeProject: Readonly<NativeProject> = {
-    enabled: args.includes('--native-project'),
-    androidProjectDirectory: getOptionValue(args, '--android-project-dir', ''),
-    iosProjectDirectory: getOptionValue(args, '--ios-project-dir', ''),
+    enabled: args.includes('--copy'),
+    androidProjectDirectory: getOptionValue(args, '--android-project', ''),
+    iosProjectDirectory: getOptionValue(args, '--ios-project', ''),
   };
 
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import et from 'elementtree';
 import { Options, PlatformOptions } from '.';
 import { getPlatforms } from './config';
 import { BadInputError } from './error';
+import { NativeProject } from './native';
 import { AdaptiveIconResourceOptions, Platform, RunPlatformOptions, SimpleResourceOptions, filterSupportedPlatforms, validatePlatforms } from './platform';
 import { DEFAULT_RESOURCES_DIRECTORY, RESOURCE_TYPES, ResourceKey, ResourceType, Source, SourceType, validateResourceTypes } from './resources';
 import { getOptionValue } from './utils/cli';
@@ -28,14 +29,18 @@ export function parseOptions(args: readonly string[]): Options {
   const resourcesDirectory = getOptionValue(args, '--resources', DEFAULT_RESOURCES_DIRECTORY);
   const platformArg = args[0] ? args[0] : undefined;
   const platformList = validatePlatforms(platformArg && !platformArg.startsWith('-') ? [platformArg] : []);
-  const nativeProjectDirectory = getOptionValue(args, '--nativeProjDir', '');
+  const nativeProject: Readonly<NativeProject> = {
+    enabled: args.includes('--native-project'),
+    androidProjectDirectory: getOptionValue(args, '--android-project-dir', ''),
+    iosProjectDirectory: getOptionValue(args, '--ios-project-dir', ''),
+  };
 
   return {
     resourcesDirectory,
     logstream: json ? process.stderr : process.stdout,
     errstream: process.stderr,
     ...platformList.length > 0 ? { platforms: generatePlatformOptions(platformList, resourcesDirectory, args) } : {},
-    nativeProjectDirectory,
+    nativeProject,
   };
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,12 +28,14 @@ export function parseOptions(args: readonly string[]): Options {
   const resourcesDirectory = getOptionValue(args, '--resources', DEFAULT_RESOURCES_DIRECTORY);
   const platformArg = args[0] ? args[0] : undefined;
   const platformList = validatePlatforms(platformArg && !platformArg.startsWith('-') ? [platformArg] : []);
+  const nativeProjectDirectory = getOptionValue(args, '--nativeProjDir', '');
 
   return {
     resourcesDirectory,
     logstream: json ? process.stderr : process.stdout,
     errstream: process.stderr,
     ...platformList.length > 0 ? { platforms: generatePlatformOptions(platformList, resourcesDirectory, args) } : {},
+    nativeProjectDirectory,
   };
 }
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -34,13 +34,13 @@ const help = `
     --icon-foreground-source <path> ...... Use file for foreground of adaptive icon
     --icon-background-source <path|hex> .. Use file or color for background of adaptive icon
 
+    --copy ............................... Enable process of copying generated resources to native projects
+    --android-project <path> ............. Use specified directory for Android native project (default: 'android')
+    --ios-project <path> ................. Use specified directory for iOS native project (default: 'ios')
+
     -h, --help ........................... Print help for the platform, then quit
     --version ............................ Print version, then quit
     --verbose ............................ Print verbose output to stderr
-
-    --native-project ..................... Enable process of copying generated resources to native projects
-    --android-project <path> ............. Use specified directory for Android native project (default: 'android')
-    --ios-project <path> ................. Use specified directory for iOS native project (default: 'ios')
 `;
 
 export async function run() {

--- a/src/help.ts
+++ b/src/help.ts
@@ -37,6 +37,10 @@ const help = `
     -h, --help ........................... Print help for the platform, then quit
     --version ............................ Print version, then quit
     --verbose ............................ Print verbose output to stderr
+
+    --native-project ..................... Enable process of copying generated resources to native projects
+    --android-project-dir ................ Use specified directory for Android native project, default to 'android' if not specified
+    --ios-project-dir .................... Use specified directory for iOS native project, default to 'ios' if not specified
 `;
 
 export async function run() {

--- a/src/help.ts
+++ b/src/help.ts
@@ -39,7 +39,7 @@ const help = `
     --verbose ............................ Print verbose output to stderr
 
     --native-project ..................... Enable process of copying generated resources to native projects
-    --android-project-dir ................ Use specified directory for Android native project, default to 'android' if not specified
+    --android-project <path> ............. Use specified directory for Android native project (default: 'android')
     --ios-project-dir .................... Use specified directory for iOS native project, default to 'ios' if not specified
 `;
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -40,7 +40,7 @@ const help = `
 
     --native-project ..................... Enable process of copying generated resources to native projects
     --android-project <path> ............. Use specified directory for Android native project (default: 'android')
-    --ios-project-dir .................... Use specified directory for iOS native project, default to 'ios' if not specified
+    --ios-project <path> ................. Use specified directory for iOS native project (default: 'ios')
 `;
 
 export async function run() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { generateRunOptions, getDirectory, resolveOptions } from './cli';
 import { getConfigPath, read as readConfig, run as runConfig, write as writeConfig } from './config';
 import { BaseError } from './error';
+import { copyToNativeProject } from './native';
 import { GeneratedResource, PLATFORMS, Platform, RunPlatformOptions, run as runPlatform } from './platform';
 import { DEFAULT_RESOURCES_DIRECTORY, Density, Orientation, ResolvedSource, SourceType } from './resources';
 import { tryFn } from './utils/fn';
@@ -43,6 +44,7 @@ async function CordovaRes({
     [Platform.IOS]: generateRunOptions(Platform.IOS, resourcesDirectory, []),
     [Platform.WINDOWS]: generateRunOptions(Platform.WINDOWS, resourcesDirectory, []),
   },
+  nativeProjectDirectory = '',
 }: CordovaRes.Options = {}): Promise<Result> {
   const configPath = getConfigPath(directory);
 
@@ -70,6 +72,9 @@ async function CordovaRes({
       logstream.write(`Generated ${platformResult.resources.length} resources for ${platform}\n`);
       resources.push(...platformResult.resources);
       sources.push(...platformResult.sources);
+      if (nativeProjectDirectory.trim() !== '') {
+        copyToNativeProject(platform, nativeProjectDirectory);
+      }
     }
   }
 
@@ -156,6 +161,13 @@ namespace CordovaRes {
      * provided, resources are generated in an explicit, opt-in manner.
      */
     readonly platforms?: Readonly<PlatformOptions>;
+
+    /**
+     * Specify target native project directory.
+     *
+     * This is for copying all generated resources directly.
+     */
+    readonly nativeProjectDirectory?: string;
   }
 
   export async function runCommandLine(args: readonly string[]): Promise<void> {

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,4 +1,5 @@
 import { copy } from '@ionic/utils-fs';
+import Debug from 'debug';
 import path from 'path';
 
 import { Platform } from './platform';
@@ -12,6 +13,8 @@ interface ProcessItem {
   source: string;
   target: string;
 }
+
+const debug = Debug('cordova-res:native');
 
 const SOURCE_IOS_ICON = 'resources/ios/icon/';
 const SOURCE_IOS_SPLASH = 'resources/ios/splash/';
@@ -149,23 +152,25 @@ const ANDROID_SPLASHES: readonly ProcessItem[] = [
   },
 ];
 
-async function copyImages(sourcePath: string, targetPath: string, images: readonly ProcessItem[], logstream: NodeJS.WritableStream) {
+async function copyImages(sourcePath: string, targetPath: string, images: readonly ProcessItem[]) {
   await Promise.all(images.map(async item => {
     const source = path.join(sourcePath, item.source);
     const target = path.join(targetPath, item.target);
     await copy(source, target);
-    logstream.write(`Copied resource item from ${source} to ${target}\n`);
+    debug(`Copied resource item from ${source} to ${target}\n`);
   }));
 }
 
 export async function copyToNativeProject(platform: Platform, nativeProject: NativeProject, logstream: NodeJS.WritableStream) {
   if (platform === Platform.IOS) {
     const iosProjectDirectory = nativeProject.iosProjectDirectory || 'ios';
-    await copyImages(SOURCE_IOS_ICON, path.join(iosProjectDirectory, TARGET_IOS_ICON), IOS_ICONS, logstream);
-    await copyImages(SOURCE_IOS_SPLASH, path.join(iosProjectDirectory, TARGET_IOS_SPLASH), IOS_SPLASHES, logstream);
+    await copyImages(SOURCE_IOS_ICON, path.join(iosProjectDirectory, TARGET_IOS_ICON), IOS_ICONS);
+    await copyImages(SOURCE_IOS_SPLASH, path.join(iosProjectDirectory, TARGET_IOS_SPLASH), IOS_SPLASHES);
+    logstream.write(`Copied ${IOS_ICONS.length + IOS_SPLASHES.length} resource items to iOS project`);
   } else if (platform === Platform.ANDROID) {
     const androidProjectDirectory = nativeProject.iosProjectDirectory || 'android';
-    await copyImages(SOURCE_ANDROID_ICON, path.join(androidProjectDirectory, TARGET_ANDROID_ICON), ANDROID_ICONS, logstream);
-    await copyImages(SOURCE_ANDROID_SPLASH, path.join(androidProjectDirectory, TARGET_ANDROID_SPLASH), ANDROID_SPLASHES, logstream);
+    await copyImages(SOURCE_ANDROID_ICON, path.join(androidProjectDirectory, TARGET_ANDROID_ICON), ANDROID_ICONS);
+    await copyImages(SOURCE_ANDROID_SPLASH, path.join(androidProjectDirectory, TARGET_ANDROID_SPLASH), ANDROID_SPLASHES);
+    logstream.write(`Copied ${ANDROID_ICONS.length + ANDROID_SPLASHES.length} resource items to Android project`);
   }
 }

--- a/src/native.ts
+++ b/src/native.ts
@@ -157,7 +157,7 @@ async function copyImages(sourcePath: string, targetPath: string, images: readon
     const source = path.join(sourcePath, item.source);
     const target = path.join(targetPath, item.target);
     await copy(source, target);
-    debug(`Copied resource item from ${source} to ${target}\n`);
+    debug('Copied resource item from %s to %s', source, target);
   }));
 }
 

--- a/src/native.ts
+++ b/src/native.ts
@@ -1,0 +1,174 @@
+import fs from 'fs';
+
+import { BadInputError } from './error';
+import { Platform } from './platform';
+
+interface Icon {
+  source: string;
+  target: string;
+}
+
+const SOURCE_IOS_ICON = 'resources/ios/icon/';
+const SOURCE_IOS_SPLASH = 'resources/ios/splash/';
+
+const TARGET_IOS_ICON = '/App/App/Assets.xcassets/AppIcon.appiconset/';
+const TARGET_IOS_SPLASH = '/App/App/Assets.xcassets/Splash.imageset/';
+
+const SOURCE_ANDROID_ICON = 'resources/android/icon/';
+const SOURCE_ANDROID_SPLASH = 'resources/android/splash/';
+
+const TARGET_ANDROID_ICON = '/app/src/main/res/';
+const TARGET_ANDROID_SPLASH = '/app/src/main/res/';
+
+const IOS_ICONS = [
+  { source: 'icon-20.png', target: 'AppIcon-20x20@1x.png' },
+  { source: 'icon-20@2x.png', target: 'AppIcon-20x20@2x.png' },
+  { source: 'icon-20@2x.png', target: 'AppIcon-20x20@2x-1.png' },
+  { source: 'icon-20@3x.png', target: 'AppIcon-20x20@3x.png' },
+  { source: 'icon-29.png', target: 'AppIcon-29x29@1x.png' },
+  { source: 'icon-29@2x.png', target: 'AppIcon-29x29@2x.png' },
+  { source: 'icon-29@2x.png', target: 'AppIcon-29x29@2x-1.png' },
+  { source: 'icon-29@3x.png', target: 'AppIcon-29x29@3x.png' },
+  { source: 'icon-40.png', target: 'AppIcon-40x40@1x.png' },
+  { source: 'icon-40@2x.png', target: 'AppIcon-40x40@2x.png' },
+  { source: 'icon-40@2x.png', target: 'AppIcon-40x40@2x-1.png' },
+  { source: 'icon-40@3x.png', target: 'AppIcon-40x40@3x.png' },
+  { source: 'icon-60@2x.png', target: 'AppIcon-60x60@2x.png' },
+  { source: 'icon-60@3x.png', target: 'AppIcon-60x60@3x.png' },
+  { source: 'icon-76.png', target: 'AppIcon-76x76@1x.png' },
+  { source: 'icon-76@2x.png', target: 'AppIcon-76x76@2x.png' },
+  { source: 'icon-83.5@2x.png', target: 'AppIcon-83.5x83.5@2x.png' },
+  { source: 'icon-1024.png', target: 'AppIcon-512@2x.png' },
+];
+const IOS_SPLASHES = [
+  { source: 'Default-Portrait@~ipadpro.png', target: 'splash-2732x2732.png' },
+  { source: 'Default-Portrait@~ipadpro.png', target: 'splash-2732x2732-1.png' },
+  { source: 'Default-Portrait@~ipadpro.png', target: 'splash-2732x2732-2.png' },
+];
+
+const ANDROID_ICONS = [
+  { source: 'drawable-ldpi-icon.png', target: 'drawable-hdpi-icon.png' },
+  { source: 'drawable-mdpi-icon.png', target: 'mipmap-mdpi/ic_launcher.png' },
+  {
+    source: 'drawable-mdpi-icon.png',
+    target: 'mipmap-mdpi/ic_launcher_round.png',
+  },
+  {
+    source: 'drawable-mdpi-icon.png',
+    target: 'mipmap-mdpi/ic_launcher_foreground.png',
+  },
+  { source: 'drawable-hdpi-icon.png', target: 'mipmap-hdpi/ic_launcher.png' },
+  {
+    source: 'drawable-hdpi-icon.png',
+    target: 'mipmap-hdpi/ic_launcher_round.png',
+  },
+  {
+    source: 'drawable-hdpi-icon.png',
+    target: 'mipmap-hdpi/ic_launcher_foreground.png',
+  },
+  { source: 'drawable-xhdpi-icon.png', target: 'mipmap-xhdpi/ic_launcher.png' },
+  {
+    source: 'drawable-xhdpi-icon.png',
+    target: 'mipmap-xhdpi/ic_launcher_round.png',
+  },
+  {
+    source: 'drawable-xhdpi-icon.png',
+    target: 'mipmap-xhdpi/ic_launcher_foreground.png',
+  },
+  {
+    source: 'drawable-xxhdpi-icon.png',
+    target: 'mipmap-xxhdpi/ic_launcher.png',
+  },
+  {
+    source: 'drawable-xxhdpi-icon.png',
+    target: 'mipmap-xxhdpi/ic_launcher_round.png',
+  },
+  {
+    source: 'drawable-xxhdpi-icon.png',
+    target: 'mipmap-xxhdpi/ic_launcher_foreground.png',
+  },
+  {
+    source: 'drawable-xxxhdpi-icon.png',
+    target: 'mipmap-xxxhdpi/ic_launcher.png',
+  },
+  {
+    source: 'drawable-xxxhdpi-icon.png',
+    target: 'mipmap-xxxhdpi/ic_launcher_round.png',
+  },
+  {
+    source: 'drawable-xxxhdpi-icon.png',
+    target: 'mipmap-xxxhdpi/ic_launcher_foreground.png',
+  },
+];
+const ANDROID_SPLASHES = [
+  { source: 'drawable-land-mdpi-screen.png', target: 'drawable/splash.png' },
+  {
+    source: 'drawable-land-mdpi-screen.png',
+    target: 'drawable-land-mdpi/splash.png',
+  },
+  {
+    source: 'drawable-land-hdpi-screen.png',
+    target: 'drawable-land-hdpi/splash.png',
+  },
+  {
+    source: 'drawable-land-xhdpi-screen.png',
+    target: 'drawable-land-xhdpi/splash.png',
+  },
+  {
+    source: 'drawable-land-xxhdpi-screen.png',
+    target: 'drawable-land-xxhdpi/splash.png',
+  },
+  {
+    source: 'drawable-land-xxxhdpi-screen.png',
+    target: 'drawable-land-xxxhdpi/splash.png',
+  },
+  {
+    source: 'drawable-port-mdpi-screen.png',
+    target: 'drawable-port-mdpi/splash.png',
+  },
+  {
+    source: 'drawable-port-hdpi-screen.png',
+    target: 'drawable-port-hdpi/splash.png',
+  },
+  {
+    source: 'drawable-port-xhdpi-screen.png',
+    target: 'drawable-port-xhdpi/splash.png',
+  },
+  {
+    source: 'drawable-port-xxhdpi-screen.png',
+    target: 'drawable-port-xxhdpi/splash.png',
+  },
+  {
+    source: 'drawable-port-xxxhdpi-screen.png',
+    target: 'drawable-port-xxxhdpi/splash.png',
+  },
+];
+
+function copyImages(sourcePath: string, targetPath: string, images: Icon[]) {
+  for (const icon of images) {
+    const source = sourcePath + icon.source;
+    const target = targetPath + icon.target;
+    fs.copyFile(source, target, err => {
+      if (err) {
+        throw err;
+      }
+    });
+  }
+}
+
+export function copyToNativeProject(platform: Platform, nativeProjectDirectory: string) {
+  if (nativeProjectDirectory === '') {
+    throw new BadInputError('Native project directory must be specified.');
+  }
+  if (nativeProjectDirectory.slice(-1) === '/') {
+    nativeProjectDirectory = nativeProjectDirectory.slice(0, nativeProjectDirectory.length - 1);
+  }
+
+  if (platform === Platform.IOS) {
+    copyImages(SOURCE_IOS_ICON, `${nativeProjectDirectory}${TARGET_IOS_ICON}`, IOS_ICONS);
+    copyImages(SOURCE_IOS_SPLASH, `${nativeProjectDirectory}${TARGET_IOS_SPLASH}`, IOS_SPLASHES);
+  } else if (platform === Platform.ANDROID) {
+    copyImages(SOURCE_ANDROID_ICON, `${nativeProjectDirectory}${TARGET_ANDROID_ICON}`, ANDROID_ICONS);
+    copyImages(SOURCE_ANDROID_SPLASH, `${nativeProjectDirectory}${TARGET_ANDROID_SPLASH}`, ANDROID_SPLASHES);
+  }
+}

--- a/src/native.ts
+++ b/src/native.ts
@@ -168,7 +168,7 @@ export async function copyToNativeProject(platform: Platform, nativeProject: Nat
     await copyImages(SOURCE_IOS_SPLASH, path.join(iosProjectDirectory, TARGET_IOS_SPLASH), IOS_SPLASHES);
     logstream.write(`Copied ${IOS_ICONS.length + IOS_SPLASHES.length} resource items to iOS project`);
   } else if (platform === Platform.ANDROID) {
-    const androidProjectDirectory = nativeProject.iosProjectDirectory || 'android';
+    const androidProjectDirectory = nativeProject.androidProjectDirectory || 'android';
     await copyImages(SOURCE_ANDROID_ICON, path.join(androidProjectDirectory, TARGET_ANDROID_ICON), ANDROID_ICONS);
     await copyImages(SOURCE_ANDROID_SPLASH, path.join(androidProjectDirectory, TARGET_ANDROID_SPLASH), ANDROID_SPLASHES);
     logstream.write(`Copied ${ANDROID_ICONS.length + ANDROID_SPLASHES.length} resource items to Android project`);


### PR DESCRIPTION
Added copying generated resources to native project directly with option '-nativeProjDir [directory]'

This is addressing enhancement for #79 

Please take a moment to review as I did not find a clear contribution guide. Let me know if any changes or improvement needed.