### PR TITLE
fix(config) Creating only one type of asset + copy-param doesn't crash

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { getConfigPath, read as readConfig, run as runConfig, write as writeConf
 import { BaseError } from './error';
 import { NativeProjectConfig, copyToNativeProject } from './native';
 import { GeneratedResource, PLATFORMS, Platform, RunPlatformOptions, prettyPlatform, run as runPlatform } from './platform';
-import { Density, Orientation, ResolvedSource, SourceType } from './resources';
+import { Density, Orientation, ResolvedSource, ResourceType, SourceType } from './resources';
 import { tryFn } from './utils/fn';
 
 const debug = Debug('cordova-res');
@@ -78,7 +78,9 @@ async function CordovaRes(options: CordovaRes.Options = {}): Promise<Result> {
       sources.push(...platformResult.sources);
 
       if (copy && nativeProject) {
-        await copyToNativeProject(platform, nativeProject, logstream, errstream);
+        const shouldCopyIcons = resources.findIndex(res => res.type === ResourceType.ICON || res.type === ResourceType.ADAPTIVE_ICON) !== -1;
+        const shouldCopySplash = resources.findIndex(res => res.type === ResourceType.SPLASH) !== -1;
+        await copyToNativeProject(platform, nativeProject, shouldCopyIcons, shouldCopySplash, logstream, errstream);
       }
     }
   }

--- a/src/native.ts
+++ b/src/native.ts
@@ -169,7 +169,7 @@ const ANDROID_SPLASHES: readonly ProcessItem[] = [
   },
 ];
 
-async function copyImages(sourcePath: string, targetPath: string, images: readonly ProcessItem[]) {
+async function copyImages(sourcePath: string, targetPath: string, images: readonly ProcessItem[]): Promise<number> {
   await Promise.all(images.map(async item => {
     const source = path.join(sourcePath, item.source);
     const target = path.join(targetPath, item.target);
@@ -178,20 +178,33 @@ async function copyImages(sourcePath: string, targetPath: string, images: readon
 
     await copy(source, target);
   }));
+
+  return images.length;
 }
 
-export async function copyToNativeProject(platform: Platform, nativeProject: NativeProjectConfig, logstream: NodeJS.WritableStream | null, errstream: NodeJS.WritableStream | null) {
+export async function copyToNativeProject(platform: Platform, nativeProject: NativeProjectConfig, shouldCopyIcons: boolean, shouldCopySplash: boolean, logstream: NodeJS.WritableStream | null, errstream: NodeJS.WritableStream | null) {
+  let count = 0;
+
   if (platform === Platform.IOS) {
     const iosProjectDirectory = nativeProject.directory || 'ios';
-    await copyImages(SOURCE_IOS_ICON, path.join(iosProjectDirectory, TARGET_IOS_ICON), IOS_ICONS);
-    await copyImages(SOURCE_IOS_SPLASH, path.join(iosProjectDirectory, TARGET_IOS_SPLASH), IOS_SPLASHES);
-    logstream?.write(util.format(`Copied %s resource items to %s`, IOS_ICONS.length + IOS_SPLASHES.length, prettyPlatform(platform)) + '\n');
+    if (shouldCopyIcons) {
+      count += await copyImages(SOURCE_IOS_ICON, path.join(iosProjectDirectory, TARGET_IOS_ICON), IOS_ICONS);
+    }
+    if (shouldCopySplash) {
+      count += await copyImages(SOURCE_IOS_SPLASH, path.join(iosProjectDirectory, TARGET_IOS_SPLASH), IOS_SPLASHES);
+    }
   } else if (platform === Platform.ANDROID) {
     const androidProjectDirectory = nativeProject.directory || 'android';
-    await copyImages(SOURCE_ANDROID_ICON, path.join(androidProjectDirectory, TARGET_ANDROID_ICON), ANDROID_ICONS);
-    await copyImages(SOURCE_ANDROID_SPLASH, path.join(androidProjectDirectory, TARGET_ANDROID_SPLASH), ANDROID_SPLASHES);
-    logstream?.write(util.format(`Copied %s resource items to %s`, ANDROID_ICONS.length + ANDROID_SPLASHES.length, prettyPlatform(platform)) + '\n');
+    if (shouldCopyIcons) {
+      count += await copyImages(SOURCE_ANDROID_ICON, path.join(androidProjectDirectory, TARGET_ANDROID_ICON), ANDROID_ICONS);
+    }
+    if (shouldCopySplash) {
+      count += await copyImages(SOURCE_ANDROID_SPLASH, path.join(androidProjectDirectory, TARGET_ANDROID_SPLASH), ANDROID_SPLASHES);
+    }
   } else {
     errstream?.write(util.format('WARN:\tCopying to native projects is not supported for %s', prettyPlatform(platform)) + '\n');
+    return;
   }
+
+  logstream?.write(util.format(`Copied %s resource items to %s`, count, prettyPlatform(platform)) + '\n');
 }


### PR DESCRIPTION
When creating only one type of asset (e.g. icons only) while specifying the --copy parameter, cordova-res does not crash anymore by avoiding unnecessary copying.


Try for yourself with the current version v0.12.0 w/o this pull request: 

Just have an icon.png in the 'resources' sub folder and issue the following command:

`cordova-res android --type icon --skip-config --copy`

After that the following error is shown as cordova-res is trying to copy splash screens which haven't been created:

`Error: ENOENT: no such file or directory, stat 'resources/android/splash/drawable-land-mdpi-screen.png'
`

